### PR TITLE
Filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ composer-%: ## Run a composer command, `make "composer-<command> [...]"`.
 # Testing
 
 test: ## Run the unit and integration testsuites.
-test: lint test-unit test-integration
+test: lint test-unit
 
 lint: ## Run phpcs against the code.
 	${DOCKER_RUN} vendor/bin/phpcs -p --warning-severity=0 src/ tests/

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "squizlabs/php_codesniffer": "^2.9",
         "graze/standards": "^1.0",
         "symfony/console": "^3.1",
-        "graze/console-diff-renderer": "^0.5.2",
+        "graze/console-diff-renderer": "^0.6",
         "mockery/mockery": "^0.9.9"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "squizlabs/php_codesniffer": "^2.9",
         "graze/standards": "^1.0",
         "symfony/console": "^3.1",
-        "graze/console-diff-renderer": "^0.5",
+        "graze/console-diff-renderer": "^0.5.2",
         "mockery/mockery": "^0.9.9"
     },
     "suggest": {

--- a/src/Run.php
+++ b/src/Run.php
@@ -57,7 +57,7 @@ class Run implements RunInterface
     {
         if (!$this->process->isRunning()) {
             $this->process->start(function ($type, $data) {
-                $this->last = trim($data);
+                $this->last = rtrim($data);
             });
             $this->started = microtime(true);
             $this->completed = false;

--- a/src/Table.php
+++ b/src/Table.php
@@ -36,6 +36,8 @@ class Table
     private $output;
     /** @var TerminalInterface */
     private $terminal;
+    /** @var bool */
+    private $showOutput = true;
 
     /**
      * Table constructor.
@@ -91,7 +93,7 @@ class Table
             $length = isset($this->maxLengths[$key]) ? '-' . $this->maxLengths[$key] : '';
             $info[] = sprintf("<info>%s</info>: %{$length}s", $key, $value);
         }
-        $extra = $extra ? '   ' . $this->terminal->filter($extra) : '';
+        $extra = $extra ? '  ' . $this->terminal->filter($extra) : '';
         return sprintf("%s (<comment>%6.2fs</comment>) %s%s", implode(' ', $info), $duration, $status, $extra);
     }
 
@@ -111,7 +113,7 @@ class Table
                     $data,
                     mb_substr(static::SPINNER, $spinner++, 1),
                     $duration,
-                    $last
+                    ($this->showOutput ? $last : '')
                 );
                 if ($spinner > mb_strlen(static::SPINNER) - 1) {
                     $spinner = 0;
@@ -175,5 +177,25 @@ class Table
         }
 
         return $output;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isShowOutput()
+    {
+        return $this->showOutput;
+    }
+
+    /**
+     * @param bool $showOutput
+     *
+     * @return $this
+     */
+    public function setShowOutput($showOutput)
+    {
+        $this->showOutput = $showOutput;
+
+        return $this;
     }
 }

--- a/src/Table.php
+++ b/src/Table.php
@@ -15,6 +15,7 @@ namespace Graze\ParallelProcess;
 
 use Exception;
 use Graze\DiffRenderer\DiffConsoleOutput;
+use Graze\DiffRenderer\Terminal\TerminalInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
@@ -33,6 +34,8 @@ class Table
     private $maxLengths = [];
     /** @var DiffConsoleOutput */
     private $output;
+    /** @var TerminalInterface */
+    private $terminal;
 
     /**
      * Table constructor.
@@ -49,6 +52,7 @@ class Table
         } else {
             $this->output = $output;
         }
+        $this->terminal = $this->output->getTerminal();
         $this->exceptions = [];
     }
 
@@ -87,7 +91,7 @@ class Table
             $length = isset($this->maxLengths[$key]) ? '-' . $this->maxLengths[$key] : '';
             $info[] = sprintf("<info>%s</info>: %{$length}s", $key, $value);
         }
-        $extra = $extra ? '   ' . $extra : '';
+        $extra = $extra ? '   ' . $this->terminal->filter($extra) : '';
         return sprintf("%s (<comment>%6.2fs</comment>) %s%s", implode(' ', $info), $duration, $status, $extra);
     }
 


### PR DESCRIPTION
- Filter the output to remove any control codes, etc
- Add an option to turn on the output or not for all processes
- Updates `graze/console-diff-renderer` to the pre-filtered version