### PR TITLE
add a limit to the number of concurrent processes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "squizlabs/php_codesniffer": "^2.9",
         "graze/standards": "^1.0",
         "symfony/console": "^3.1",
-        "graze/console-diff-renderer": "^0.6",
+        "graze/console-diff-renderer": "^0.6.1",
         "mockery/mockery": "^0.9.9"
     },
     "suggest": {

--- a/src/Exceptions/NotRunningException.php
+++ b/src/Exceptions/NotRunningException.php
@@ -4,6 +4,6 @@ namespace Graze\ParallelProcess\Exceptions;
 
 use RuntimeException;
 
-class AlreadyRunningException extends RuntimeException
+class NotRunningException extends RuntimeException
 {
 }

--- a/src/Run.php
+++ b/src/Run.php
@@ -2,7 +2,6 @@
 
 namespace Graze\ParallelProcess;
 
-use Graze\ParallelProcess\Exceptions\AlreadyRunningException;
 use Symfony\Component\Process\Process;
 
 class Run implements RunInterface
@@ -61,8 +60,6 @@ class Run implements RunInterface
             });
             $this->started = microtime(true);
             $this->completed = false;
-        } else {
-            throw new AlreadyRunningException("start: this run is already running");
         }
 
         return $this;
@@ -73,7 +70,7 @@ class Run implements RunInterface
      *
      * @return bool true if the process is currently running (started and not terminated)
      */
-    public function isRunning()
+    public function poll()
     {
         if ($this->completed || !$this->hasStarted()) {
             return false;
@@ -93,6 +90,16 @@ class Run implements RunInterface
             $this->update($this->onFailure);
         }
         return false;
+    }
+
+    /**
+     * Return if the underlying process is running
+     *
+     * @return bool
+     */
+    public function isRunning()
+    {
+        return $this->process->isRunning();
     }
 
     /**

--- a/src/RunInterface.php
+++ b/src/RunInterface.php
@@ -18,7 +18,7 @@ interface RunInterface
      *
      * @return $this
      *
-     * @throws \Graze\ParallelProcess\Exceptions\AlreadyRunningException
+     * @throws \Graze\ParallelProcess\Exceptions\NotRunningException
      */
     public function start();
 
@@ -30,9 +30,16 @@ interface RunInterface
     public function isSuccessful();
 
     /**
-     * Polls to see if this process is running
+     * We think this is running
      *
      * @return bool
      */
     public function isRunning();
+
+    /**
+     * Pools to see if this process is running
+     *
+     * @return bool
+     */
+    public function poll();
 }

--- a/src/Table.php
+++ b/src/Table.php
@@ -191,6 +191,9 @@ class Table
             $this->render();
         }
         $output = $this->processPool->run($checkInterval);
+        if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE && $this->showSummary) {
+            $this->render();
+        }
 
         if (count($this->exceptions) > 0) {
             foreach ($this->exceptions as $exception) {

--- a/src/Table.php
+++ b/src/Table.php
@@ -38,6 +38,8 @@ class Table
     private $terminal;
     /** @var bool */
     private $showOutput = true;
+    /** @var bool */
+    private $showSummary = true;
 
     /**
      * Table constructor.
@@ -142,6 +144,27 @@ class Table
     }
 
     /**
+     * @return string
+     */
+    private function getSummary()
+    {
+        if ($this->processPool->hasStarted()) {
+            if ($this->processPool->isRunning()) {
+                return sprintf(
+                    '<comment>Total</comment>: %2d, <comment>Running</comment>: %2d, <comment>Waiting</comment>: %2d',
+                    $this->processPool->count(),
+                    count($this->processPool->getRunning()),
+                    count($this->processPool->getWaiting())
+                );
+            } else {
+                return '';
+            }
+        } else {
+            return 'waiting...';
+        }
+    }
+
+    /**
      * Render a specific row
      *
      * @param int $row
@@ -149,7 +172,8 @@ class Table
     private function render($row = 0)
     {
         if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
-            $this->output->reWrite($this->rows, true);
+            $rows = ($this->showSummary ? array_merge($this->rows, [$this->getSummary()]) : $this->rows);
+            $this->output->reWrite($rows, !$this->showSummary);
         } else {
             $this->output->writeln($this->rows[$row]);
         }
@@ -195,7 +219,25 @@ class Table
     public function setShowOutput($showOutput)
     {
         $this->showOutput = $showOutput;
+        return $this;
+    }
 
+    /**
+     * @return bool
+     */
+    public function isShowSummary()
+    {
+        return $this->showSummary;
+    }
+
+    /**
+     * @param bool $showSummary
+     *
+     * @return $this
+     */
+    public function setShowSummary($showSummary)
+    {
+        $this->showSummary = $showSummary;
         return $this;
     }
 }

--- a/tests/example/app.php
+++ b/tests/example/app.php
@@ -21,7 +21,9 @@ use Symfony\Component\Process\Process;
 
 $output = new ConsoleOutput(ConsoleOutput::VERBOSITY_VERY_VERBOSE);
 
-$table = new Table($output);
+$pool = new \Graze\ParallelProcess\Pool();
+$pool->setMaxSimultaneous(3);
+$table = new Table($output, $pool);
 for ($i = 0; $i < 5; $i++) {
     $time = $i + 5;
     $table->add(new Process(sprintf('for i in `seq 1 %d` ; do date ; sleep 1 ; done', $time)), ['sleep' => $time]);

--- a/tests/unit/PoolMaxSimultaneousTest.php
+++ b/tests/unit/PoolMaxSimultaneousTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * This file is part of graze/parallel-process.
+ *
+ * Copyright (c) 2017 Nature Delivered Ltd. <https://www.graze.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license https://github.com/graze/parallel-process/blob/master/LICENSE.md
+ * @link    https://github.com/graze/parallel-process
+ */
+
+namespace Graze\ParallelProcess\Test\Unit;
+
+use Graze\ParallelProcess\Pool;
+use Graze\ParallelProcess\Run;
+use Graze\ParallelProcess\Test\TestCase;
+use Mockery;
+use Symfony\Component\Process\Process;
+
+class PoolMaxSimultaneousTest extends TestCase
+{
+    /** @var mixed */
+    private $process;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->process = Mockery::mock(Process::class);
+        $this->process->shouldReceive('stop');
+        $this->process->shouldReceive('isStarted')->andReturn(false);
+        $this->process->shouldReceive('isRunning')->andReturn(false);
+    }
+
+    public function testProperties()
+    {
+        $pool = new Pool();
+
+        $this->assertEquals(-1, $pool->getMaxSimultaneous());
+        $this->assertSame($pool, $pool->setMaxSimultaneous(1));
+        $this->assertEquals(1, $pool->getMaxSimultaneous());
+    }
+
+    public function testSingleMaxAdding2Processes()
+    {
+        $pool = new Pool();
+        $this->assertSame($pool, $pool->setMaxSimultaneous(1));
+
+        $this->assertEquals(1, $pool->getMaxSimultaneous());
+
+        $pool->add($this->process);
+
+        $process = Mockery::mock(Process::class);
+        $process->shouldReceive('stop');
+        $process->shouldReceive('isStarted')->andReturn(false);
+        $process->shouldReceive('isRunning')->andReturn(false);
+
+        $pool->add($process);
+
+        $this->process->shouldReceive('start');
+
+        $pool->start();
+
+        $this->assertCount(1, $pool->getRunning());
+        $this->assertCount(1, $pool->getWaiting());
+
+        $running = $pool->getRunning();
+        $run = reset($running);
+        $this->assertInstanceOf(Run::class, $run);
+        $this->assertSame($this->process, $run->getProcess(), 'first process added should be run first');
+
+        $waiting = $pool->getWaiting();
+        $run = reset($waiting);
+        $this->assertInstanceOf(Run::class, $run);
+        $this->assertSame($process, $run->getProcess(), 'second process added should be waiting');
+
+        $process->shouldReceive('start');
+
+        $this->assertTrue($pool->poll()); // check running state
+
+        $this->assertCount(1, $pool->getRunning());
+        $this->assertCount(0, $pool->getWaiting());
+
+        $running = $pool->getRunning();
+        $run = reset($running);
+        $this->assertInstanceOf(Run::class, $run);
+        $this->assertSame($process, $run->getProcess(), 'second process added should now be running');
+
+        $this->assertFalse($pool->poll());
+
+        $this->assertCount(0, $pool->getRunning());
+        $this->assertCount(0, $pool->getWaiting());
+    }
+
+    public function testAddingTooManyProcessesPutsThemOnTheWaitingList()
+    {
+        $pool = new Pool([], null, null, null, 1);
+        $this->assertEquals(1, $pool->getMaxSimultaneous());
+
+        $pool->add($this->process);
+
+        $process = Mockery::mock(Process::class);
+        $process->shouldReceive('stop');
+        $process->shouldReceive('isStarted')->andReturn(false);
+        $process->shouldReceive('isRunning')->andReturn(false);
+
+        $this->process->shouldReceive('start');
+
+        $pool->start();
+
+        $this->assertCount(1, $pool->getRunning());
+        $this->assertCount(0, $pool->getWaiting());
+
+        $pool->add($process);
+
+        $this->assertCount(1, $pool->getRunning());
+        $this->assertCount(1, $pool->getWaiting());
+    }
+}

--- a/tests/unit/RunTest.php
+++ b/tests/unit/RunTest.php
@@ -78,8 +78,8 @@ class RunTest extends TestCase
         $process->shouldReceive('isSuccessful')
                 ->andReturn(true);
 
-        $this->assertTrue($run->isRunning());
-        $this->assertFalse($run->isRunning());
+        $this->assertTrue($run->poll());
+        $this->assertFalse($run->poll());
         $this->assertTrue($run->isSuccessful());
         $this->assertTrue($run->hasStarted());
     }
@@ -102,7 +102,7 @@ class RunTest extends TestCase
         $process->shouldReceive('isSuccessful')->once()->andReturn(true);
 
         $run->start();
-        $this->assertFalse($run->isRunning());
+        $this->assertFalse($run->poll());
     }
 
     public function testOnFailure()
@@ -123,7 +123,7 @@ class RunTest extends TestCase
         $process->shouldReceive('isSuccessful')->once()->andReturn(false);
 
         $run->start();
-        $this->assertFalse($run->isRunning());
+        $this->assertFalse($run->poll());
     }
 
     public function testOnProgress()
@@ -144,14 +144,11 @@ class RunTest extends TestCase
         $process->shouldReceive('isSuccessful')->once()->andReturn(true);
 
         $run->start();
-        $this->assertTrue($run->isRunning());
-        $this->assertFalse($run->isRunning());
+        $this->assertTrue($run->poll());
+        $this->assertFalse($run->poll());
     }
 
-    /**
-     * @expectedException \Graze\ParallelProcess\Exceptions\AlreadyRunningException
-     */
-    public function testStartingAfterStartedWillThrowAnException()
+    public function testStartingAfterStartedWillDoNothing()
     {
         $process = Mockery::mock(Process::class);
         $process->shouldReceive('stop');
@@ -161,7 +158,7 @@ class RunTest extends TestCase
         $process->shouldReceive('isRunning')
                 ->andReturn(true);
 
-        $run->start();
+        $this->assertSame($run, $run->start());
     }
 
     public function testEventsProvideDurationAndLastMessage()
@@ -188,6 +185,6 @@ class RunTest extends TestCase
         $process->shouldReceive('isSuccessful')->once()->andReturn(true);
 
         $run->start();
-        $this->assertFalse($run->isRunning());
+        $this->assertFalse($run->poll());
     }
 }

--- a/tests/unit/TableTest.php
+++ b/tests/unit/TableTest.php
@@ -375,7 +375,7 @@ DOC
                     [
                         '%<info>key</info>: value <info>run</info>: 0 \(<comment>  0.00s</comment>\) %',
                         '%<info>key</info>: value <info>run</info>: 1 \(<comment>  0.00s</comment>\) %',
-                        '%%',
+                        '%^$%',
                     ],
                     [
                         '%<info>key</info>: value <info>run</info>: 0 \(<comment>[ 0-9\.s]+</comment>\) [⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]%',
@@ -396,6 +396,11 @@ DOC
                         '%<info>key</info>: value <info>run</info>: 0 \(<comment>[ 0-9\.s]+</comment>\) <info>✓</info>%',
                         '%<info>key</info>: value <info>run</info>: 1 \(<comment>[ 0-9\.s]+</comment>\) <info>✓</info>%',
                         '%<comment>Total</comment>:  2, <comment>Running</comment>:  2, <comment>Waiting</comment>:  0%',
+                    ],
+                    [
+                        '%<info>key</info>: value <info>run</info>: 0 \(<comment>[ 0-9\.s]+</comment>\) <info>✓</info>%',
+                        '%<info>key</info>: value <info>run</info>: 1 \(<comment>[ 0-9\.s]+</comment>\) <info>✓</info>%',
+                        '%^$%',
                     ],
                 ],
             ],

--- a/tests/unit/TableTest.php
+++ b/tests/unit/TableTest.php
@@ -44,24 +44,38 @@ class TableTest extends TestCase
 
         $this->assertTrue($table->isShowOutput());
 
-        $table->setShowOutput(false);
+        $this->assertSame($table, $table->setShowOutput(false));
 
         $this->assertFalse($table->isShowOutput());
     }
 
+    public function testShowSummary()
+    {
+        $output = Mockery::mock(ConsoleOutputInterface::class);
+        $table = new Table($output);
+
+        $this->assertTrue($table->isShowSummary());
+
+        $this->assertSame($table, $table->setShowSummary(false));
+
+        $this->assertFalse($table->isShowSummary());
+    }
+
     public function testSpinnerLoop()
     {
+        $this->table->setShowSummary(false);
         $this->output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
 
         $process = Mockery::mock(Process::class);
         $process->shouldReceive('stop');
         $process->shouldReceive('start')->once();
-        $process->shouldReceive('isStarted')->andReturn(false, true);
+        $process->shouldReceive('isStarted')->andReturn(true);
         $process->shouldReceive('isRunning')->andReturn(
             false, // add
-            true,  // start
+            false, // start
             true,  // check
             true,  // ...
+            true,
             true,
             true,
             true,
@@ -104,15 +118,17 @@ class TableTest extends TestCase
      *
      * @param int        $verbosity     OutputInterface::VERBOSITY_*
      * @param bool       $showOutput    Should it display some output text
+     * @param bool       $showSummary   Should we show a summary
      * @param bool[]     $processStates an entry for each process to run, true = success, false = failure
      * @param string[][] $outputs       Regex patterns for the output string
      *
      * @throws \Exception
      */
-    public function testOutput($verbosity, $showOutput, array $processStates, array $outputs)
+    public function testOutput($verbosity, $showOutput, $showSummary, array $processStates, array $outputs)
     {
         $this->output->setVerbosity($verbosity);
         $this->table->setShowOutput($showOutput);
+        $this->table->setShowSummary($showSummary);
 
         $oneFails = false;
 
@@ -123,8 +139,8 @@ class TableTest extends TestCase
                 call_user_func($closure, Process::OUT, 'some text');
                 return true;
             }))->once();
-            $process->shouldReceive('isStarted')->andReturn(false, true);
-            $process->shouldReceive('isRunning')->andReturn(false, true, false); // add, start, check, check
+            $process->shouldReceive('isStarted')->andReturn(true);
+            $process->shouldReceive('isRunning')->andReturn(false, false, true, false); // add, start, check, check
             $process->shouldReceive('isSuccessful')->atLeast()->once()->andReturn($processStates[$i]);
             $process->shouldReceive('getOutput')->andReturn('some text');
 
@@ -168,7 +184,7 @@ class TableTest extends TestCase
         for ($i = 0; $i < count($expected); $i++) {
             $this->assertSameSize($expected[$i], $actual[$i]);
             for ($j = 0; $j < count($expected[$i]); $j++) {
-                $this->assertRegExp($expected[$i][$j], $actual[$i][$j]);
+                $this->assertRegExp($expected[$i][$j], $actual[$i][$j], sprintf('group: %d, line: %d', $i + 1, $j + 1));
             }
         }
     }
@@ -182,6 +198,7 @@ class TableTest extends TestCase
             [ // verbose with single valid run
                 OutputInterface::VERBOSITY_VERBOSE,
                 false,
+                false,
                 [true],
                 [
                     ['%<info>key</info>: value <info>run</info>: 0 \(<comment>  0.00s</comment>\) %'],
@@ -192,6 +209,7 @@ class TableTest extends TestCase
             [ // normal verbosity only writes a single line
                 OutputInterface::VERBOSITY_NORMAL,
                 false,
+                false,
                 [true],
                 [
                     ['%<info>key</info>: value <info>run</info>: 0 \(<comment>[ 0-9\.s]+</comment>\) <info>✓</info>%'],
@@ -199,6 +217,7 @@ class TableTest extends TestCase
             ],
             [
                 OutputInterface::VERBOSITY_NORMAL,
+                false,
                 false,
                 [true, true],
                 [
@@ -208,6 +227,7 @@ class TableTest extends TestCase
             ],
             [ // multiple runs with verbosity will update each item one at a time
                 OutputInterface::VERBOSITY_VERBOSE,
+                false,
                 false,
                 [true, true],
                 [
@@ -236,6 +256,7 @@ class TableTest extends TestCase
             [ // errors will display an error
                 OutputInterface::VERBOSITY_VERBOSE,
                 false,
+                false,
                 [false],
                 [
                     ['%<info>key</info>: value <info>run</info>: 0 \(<comment>  0.00s</comment>\) %'],
@@ -264,6 +285,7 @@ DOC
             [ // errors will display an error
                 OutputInterface::VERBOSITY_NORMAL,
                 false,
+                false,
                 [false],
                 [
                     ['%<info>key</info>: value <info>run</info>: 0 \(<comment>[ 0-9\.s]+</comment>\) <error>x</error>%'],
@@ -289,6 +311,7 @@ DOC
             ],
             [ // multiple runs with verbosity will update each item one at a time
                 OutputInterface::VERBOSITY_VERBOSE,
+                false,
                 false,
                 [true, false],
                 [
@@ -335,11 +358,45 @@ DOC
             [ // include output
                 OutputInterface::VERBOSITY_VERBOSE,
                 true,
+                false,
                 [true],
                 [
                     ['%(*UTF8)<info>key</info>: value <info>run</info>: 0 \(<comment>  0.00s</comment>\) %'],
                     ['%(*UTF8)<info>key</info>: value <info>run</info>: 0 \(<comment>[ 0-9\.s]+</comment>\) [⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]  some text%'],
                     ['%(*UTF8)<info>key</info>: value <info>run</info>: 0 \(<comment>[ 0-9\.s]+</comment>\) <info>✓</info>  some text%'],
+                ],
+            ],
+            [ // include a summary
+                OutputInterface::VERBOSITY_VERBOSE,
+                false,
+                true,
+                [true, true],
+                [
+                    [
+                        '%<info>key</info>: value <info>run</info>: 0 \(<comment>  0.00s</comment>\) %',
+                        '%<info>key</info>: value <info>run</info>: 1 \(<comment>  0.00s</comment>\) %',
+                        '%%',
+                    ],
+                    [
+                        '%<info>key</info>: value <info>run</info>: 0 \(<comment>[ 0-9\.s]+</comment>\) [⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]%',
+                        '%<info>key</info>: value <info>run</info>: 1 \(<comment>  0.00s</comment>\) %',
+                        '%<comment>Total</comment>:  2, <comment>Running</comment>:  2, <comment>Waiting</comment>:  0%',
+                    ],
+                    [
+                        '%<info>key</info>: value <info>run</info>: 0 \(<comment>[ 0-9\.s]+</comment>\) [⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]%',
+                        '%<info>key</info>: value <info>run</info>: 1 \(<comment>[ 0-9\.s]+</comment>\) [⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]%',
+                        '%<comment>Total</comment>:  2, <comment>Running</comment>:  2, <comment>Waiting</comment>:  0%',
+                    ],
+                    [
+                        '%<info>key</info>: value <info>run</info>: 0 \(<comment>[ 0-9\.s]+</comment>\) <info>✓</info>%',
+                        '%<info>key</info>: value <info>run</info>: 1 \(<comment>[ 0-9\.s]+</comment>\) [⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]%',
+                        '%<comment>Total</comment>:  2, <comment>Running</comment>:  2, <comment>Waiting</comment>:  0%',
+                    ],
+                    [
+                        '%<info>key</info>: value <info>run</info>: 0 \(<comment>[ 0-9\.s]+</comment>\) <info>✓</info>%',
+                        '%<info>key</info>: value <info>run</info>: 1 \(<comment>[ 0-9\.s]+</comment>\) <info>✓</info>%',
+                        '%<comment>Total</comment>:  2, <comment>Running</comment>:  2, <comment>Waiting</comment>:  0%',
+                    ],
                 ],
             ],
         ];


### PR DESCRIPTION
Add an optional limit to the number of concurrent processes

- Adds `setMaxSimultaneous` and `getMaxSimultaneous` methods on `Pool`
  - Keeps a list of processes to run in the waiting column until there is space
- Adds `setShowSummary` and `isShowSummary` on `Table` to display or not a summary line of each process `Total: 3, Running: 2, Waiting: 1`

Fixes #8 