### PR TITLE
coverage->100%, refactor priorities, add more tests to prioritypool

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1802,16 +1802,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.3.1",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec"
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/628a481780561150481a9ec74709092b9759b3ec",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6ad28354c04b364c3c71a34e4a18b629cc3b231e",
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e",
                 "shasum": ""
             },
             "require": {
@@ -1849,7 +1849,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-07-26T23:47:18+00:00"
+            "time": "2018-09-23T23:08:17+00:00"
         },
         {
             "name": "symfony/console",

--- a/src/CallbackRun.php
+++ b/src/CallbackRun.php
@@ -15,13 +15,15 @@ namespace Graze\ParallelProcess;
 
 use Exception;
 use Graze\ParallelProcess\Event\EventDispatcherTrait;
+use Graze\ParallelProcess\Event\PriorityChangedEvent;
 use Graze\ParallelProcess\Event\RunEvent;
 use Throwable;
 
-class CallbackRun implements RunInterface, OutputterInterface
+class CallbackRun implements RunInterface, OutputterInterface, PrioritisedInterface
 {
     use EventDispatcherTrait;
     use RunningStateTrait;
+    use PrioritisedTrait;
 
     /** @var callable */
     private $callback;
@@ -33,8 +35,6 @@ class CallbackRun implements RunInterface, OutputterInterface
     private $exception = null;
     /** @var string */
     private $last;
-    /** @var float */
-    private $priority;
 
     /**
      * Run constructor.
@@ -52,17 +52,6 @@ class CallbackRun implements RunInterface, OutputterInterface
     }
 
     /**
-     * @param float $priority
-     *
-     * @return CallbackRun
-     */
-    public function setPriority($priority)
-    {
-        $this->priority = $priority;
-        return $this;
-    }
-
-    /**
      * @return string[]
      */
     protected function getEventNames()
@@ -73,6 +62,7 @@ class CallbackRun implements RunInterface, OutputterInterface
             RunEvent::SUCCESSFUL,
             RunEvent::FAILED,
             RunEvent::UPDATED,
+            PriorityChangedEvent::CHANGED,
         ];
     }
 
@@ -215,13 +205,5 @@ class CallbackRun implements RunInterface, OutputterInterface
     public function getLastMessageType()
     {
         return '';
-    }
-
-    /**
-     * @return float The priority for this run, where the larger the number the higher the priority
-     */
-    public function getPriority()
-    {
-        return $this->priority;
     }
 }

--- a/src/Display/Table.php
+++ b/src/Display/Table.php
@@ -150,16 +150,14 @@ class Table
      */
     private function getSummary()
     {
-        if (!$this->pool instanceof RunInterface) {
-            return '';
-        }
-
-        if ($this->pool->hasStarted()) {
-            if ($this->pool->isRunning()) {
+        $running = count($this->pool->getRunning());
+        $finished = count($this->pool->getFinished());
+        if ($running > 0 || $finished > 0) {
+            if ($running > 0) {
                 return sprintf(
                     '<comment>Total</comment>: %2d, <comment>Running</comment>: %2d, <comment>Waiting</comment>: %2d',
                     $this->pool->count(),
-                    count($this->pool->getRunning()),
+                    $running,
                     count($this->pool->getWaiting())
                 );
             } else {

--- a/src/Event/PriorityChangedEvent.php
+++ b/src/Event/PriorityChangedEvent.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of graze/parallel-process.
+ *
+ * Copyright © 2018 Nature Delivered Ltd. <https://www.graze.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license https://github.com/graze/parallel-process/blob/master/LICENSE.md
+ * @link    https://github.com/graze/parallel-process
+ */
+
+namespace Graze\ParallelProcess\Event;
+
+use Graze\ParallelProcess\PrioritisedInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+class PriorityChangedEvent extends Event
+{
+    const CHANGED = 'priority.changed';
+
+    /** @var PrioritisedInterface */
+    private $item;
+    /** @var float */
+    private $priority;
+    /** @var float|null */
+    private $oldPriority;
+
+    /**
+     * RunEvent constructor.
+     *
+     * @param PrioritisedInterface $item
+     * @param float                $priority
+     * @param float|null           $oldPriority
+     */
+    public function __construct(PrioritisedInterface $item, $priority, $oldPriority = null)
+    {
+        $this->item = $item;
+        $this->priority = $priority;
+        $this->oldPriority = $oldPriority;
+    }
+
+    /**
+     * @return PrioritisedInterface
+     */
+    public function getItem()
+    {
+        return $this->item;
+    }
+}

--- a/src/Monitor/PoolLogger.php
+++ b/src/Monitor/PoolLogger.php
@@ -104,7 +104,11 @@ class PoolLogger
     public function onRunSuccessful(RunEvent $event)
     {
         $this->logger->debug(
-            sprintf('run [%s:%s]: successfully finished', get_class($event->getRun()), spl_object_hash($event->getRun())),
+            sprintf(
+                'run [%s:%s]: successfully finished',
+                get_class($event->getRun()),
+                spl_object_hash($event->getRun())
+            ),
             $this->getTags($event->getRun())
         );
     }
@@ -137,7 +141,11 @@ class PoolLogger
     public function onRunCompleted(RunEvent $event)
     {
         $this->logger->debug(
-            sprintf('run [%s:%s]: has finished running', get_class($event->getRun()), spl_object_hash($event->getRun())),
+            sprintf(
+                'run [%s:%s]: has finished running',
+                get_class($event->getRun()),
+                spl_object_hash($event->getRun())
+            ),
             $this->getTags($event->getRun())
         );
     }
@@ -151,10 +159,8 @@ class PoolLogger
     {
         if ($item instanceof PoolInterface) {
             return $this->getPoolTags($item);
-        } elseif ($item instanceof RunInterface) {
-            return $this->getRunTags($item);
         }
-        return [];
+        return $this->getRunTags($item);
     }
 
     /**

--- a/src/PrioritisedInterface.php
+++ b/src/PrioritisedInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Graze\ParallelProcess;
+
+interface PrioritisedInterface
+{
+    /**
+     * Get the priority for this item. The higher the number the higher the priority
+     *
+     * @return float
+     */
+    public function getPriority();
+
+    /**
+     * Fluent call for setting the priority.
+     *
+     * @param float $priority The higher the number the higher the priority
+     *
+     * @return $this
+     */
+    public function setPriority($priority);
+}

--- a/src/PrioritisedTrait.php
+++ b/src/PrioritisedTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Graze\ParallelProcess;
+
+use Graze\ParallelProcess\Event\DispatcherInterface;
+use Graze\ParallelProcess\Event\PriorityChangedEvent;
+
+trait PrioritisedTrait
+{
+    /** @var float */
+    protected $priority;
+
+    /**
+     * @param float $priority
+     *
+     * @return $this
+     */
+    public function setPriority($priority)
+    {
+        $oldPriority = $this->priority;
+        $this->priority = $priority;
+        if (!($this instanceof RunInterface && $this->hasStarted())
+            && $this instanceof DispatcherInterface
+            && $this instanceof PrioritisedInterface) {
+            $this->dispatch(PriorityChangedEvent::CHANGED, new PriorityChangedEvent($this, $priority, $oldPriority));
+        }
+        return $this;
+    }
+
+    /**
+     * @return float
+     */
+    public function getPriority()
+    {
+        return $this->priority;
+    }
+}

--- a/src/PrioritisedTrait.php
+++ b/src/PrioritisedTrait.php
@@ -20,7 +20,7 @@ trait PrioritisedTrait
         $oldPriority = $this->priority;
         $this->priority = $priority;
         if (!($this instanceof RunInterface && $this->hasStarted())
-            && $this instanceof DispatcherInterface
+            && method_exists($this, 'dispatch')
             && $this instanceof PrioritisedInterface) {
             $this->dispatch(PriorityChangedEvent::CHANGED, new PriorityChangedEvent($this, $priority, $oldPriority));
         }

--- a/src/PriorityPool.php
+++ b/src/PriorityPool.php
@@ -14,6 +14,7 @@
 namespace Graze\ParallelProcess;
 
 use Graze\ParallelProcess\Event\PoolRunEvent;
+use Graze\ParallelProcess\Event\PriorityChangedEvent;
 use Graze\ParallelProcess\Exceptions\NotRunningException;
 use SplPriorityQueue;
 use Symfony\Component\Process\Process;
@@ -100,12 +101,31 @@ class PriorityPool extends Pool
 
         if ($item instanceof RunInterface && !$item->hasStarted()) {
             $this->waitingQueue->insert($item, $item->getPriority());
-            if ($this->isRunning() || $this->runInstantly) {
+            if ($this->runInstantly) {
                 $this->startNext();
             }
         }
 
+        if ($item instanceof PrioritisedInterface) {
+            $item->addListener(PriorityChangedEvent::CHANGED, [$this, 'onPriorityChanged']);
+        }
+
         return $this;
+    }
+
+    /**
+     * @param PriorityChangedEvent $event
+     */
+    public function onPriorityChanged(PriorityChangedEvent $event)
+    {
+        $index = array_search($event->getItem(), $this->waiting, true);
+        if ($index !== false) {
+            // we are unable to delete an item from a SplPriorityQueue, so we delete it and start again here
+            $this->waitingQueue = new SplPriorityQueue();
+            foreach ($this->waiting as $item) {
+                $this->waitingQueue->insert($item, $item->getPriority());
+            }
+        }
     }
 
     /**

--- a/src/PriorityPool.php
+++ b/src/PriorityPool.php
@@ -13,6 +13,7 @@
 
 namespace Graze\ParallelProcess;
 
+use Graze\ParallelProcess\Event\DispatcherInterface;
 use Graze\ParallelProcess\Event\PoolRunEvent;
 use Graze\ParallelProcess\Event\PriorityChangedEvent;
 use Graze\ParallelProcess\Exceptions\NotRunningException;
@@ -106,7 +107,7 @@ class PriorityPool extends Pool
             }
         }
 
-        if ($item instanceof PrioritisedInterface) {
+        if ($item instanceof PrioritisedInterface && $item instanceof DispatcherInterface) {
             $item->addListener(PriorityChangedEvent::CHANGED, [$this, 'onPriorityChanged']);
         }
 

--- a/src/ProcessRun.php
+++ b/src/ProcessRun.php
@@ -15,15 +15,17 @@ namespace Graze\ParallelProcess;
 
 use Exception;
 use Graze\ParallelProcess\Event\EventDispatcherTrait;
+use Graze\ParallelProcess\Event\PriorityChangedEvent;
 use Graze\ParallelProcess\Event\RunEvent;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 use Throwable;
 
-class ProcessRun implements RunInterface, OutputterInterface
+class ProcessRun implements RunInterface, OutputterInterface, PrioritisedInterface
 {
     use EventDispatcherTrait;
     use RunningStateTrait;
+    use PrioritisedTrait;
 
     /** @var Process */
     private $process;
@@ -41,8 +43,6 @@ class ProcessRun implements RunInterface, OutputterInterface
     private $updateOnProcessOutput = true;
     /** @var string[] */
     private $tags;
-    /** @var float */
-    private $priority;
 
     /**
      * Run constructor.
@@ -59,17 +59,6 @@ class ProcessRun implements RunInterface, OutputterInterface
     }
 
     /**
-     * @param float $priority
-     *
-     * @return ProcessRun
-     */
-    public function setPriority($priority)
-    {
-        $this->priority = $priority;
-        return $this;
-    }
-
-    /**
      * @return string[]
      */
     protected function getEventNames()
@@ -80,6 +69,7 @@ class ProcessRun implements RunInterface, OutputterInterface
             RunEvent::FAILED,
             RunEvent::UPDATED,
             RunEvent::SUCCESSFUL,
+            PriorityChangedEvent::CHANGED,
         ];
     }
 
@@ -260,13 +250,5 @@ class ProcessRun implements RunInterface, OutputterInterface
             return [new ProcessFailedException($this->process)];
         }
         return [];
-    }
-
-    /**
-     * @return float The priority for this run, where the larger the number the higher the priority
-     */
-    public function getPriority()
-    {
-        return $this->priority;
     }
 }

--- a/tests/unit/Display/TableTest.php
+++ b/tests/unit/Display/TableTest.php
@@ -13,9 +13,11 @@
 
 namespace Graze\ParallelProcess\Test\Unit\Display;
 
+use Graze\ParallelProcess\Display\Table;
+use Graze\ParallelProcess\Event\PoolRunEvent;
+use Graze\ParallelProcess\PoolInterface;
 use Graze\ParallelProcess\PriorityPool;
 use Graze\ParallelProcess\ProcessRun;
-use Graze\ParallelProcess\Display\Table;
 use Graze\ParallelProcess\Test\BufferDiffOutput;
 use Graze\ParallelProcess\Test\TestCase;
 use Mockery;

--- a/tests/unit/ProcessRunTest.php
+++ b/tests/unit/ProcessRunTest.php
@@ -372,7 +372,7 @@ class ProcessRunTest extends TestCase
     public function testGetPriority()
     {
         $process = Mockery::mock(Process::class);
-        $process->shouldReceive('stop');
+        $process->allows(['stop' => null, 'isStarted' => false]);
         $run = new ProcessRun($process, [], 1.5);
 
         $this->assertEquals(1.5, $run->getPriority());


### PR DESCRIPTION
- Code Coverage to: 💯
- `PriorityPool` recognises when an item changes it priority and re-orders the queue to reflect the changes.
- `Pool` triggers started and completed events when adding items that have started or are finished themselves.