### PR TITLE
Changes for PHP 8.1 and  Symfony process (5) - Event Dispatcher( 5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
+  - 8.1
   - nightly
 
 env:
@@ -22,7 +24,7 @@ env:
 
 matrix:
   allow_failures:
-    - php: 7.4
+    - php: 8.1
     - php: nightly
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
   ],
   "require": {
     "php": "^5.5 | ^7.0 | ^8.0",
-    "symfony/process": "^2.8 | ^3.2 | ^4.0",
+    "symfony/process": "^2.8 | ^3.2 | ^4.0" | ^5.0",
     "graze/data-structure": "^2.0",
-    "symfony/event-dispatcher": "^2.8 | ^3.2 | ^4.0",
+    "symfony/event-dispatcher": "^2.8 | ^3.2 | ^4.0" | ^5.0",
     "psr/log": "^1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
   ],
   "require": {
     "php": "^5.5 | ^7.0 | ^8.0",
-    "symfony/process": "^2.8 | ^3.2 | ^4.0",
+    "symfony/process": "^2.8 | ^3.2 | ^4.0 | ^5.0",
     "graze/data-structure": "^2.0",
-    "symfony/event-dispatcher": "^2.8 | ^3.2 | ^4.0",
+    "symfony/event-dispatcher": "^2.8 | ^3.2 | ^4.0 | ^5.0",
     "psr/log": "^1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     }
   ],
   "require": {
-    "php": "^5.5 | ^7.0",
+    "php": "^5.5 | ^7.0 | ^8.0",
     "symfony/process": "^2.8 | ^3.2 | ^4.0",
     "graze/data-structure": "^2.0",
     "symfony/event-dispatcher": "^2.8 | ^3.2 | ^4.0",

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
   ],
   "require": {
     "php": "^5.5 | ^7.0 | ^8.0",
-    "symfony/process": "^2.8 | ^3.2 | ^4.0" | ^5.0",
+    "symfony/process": "^2.8 | ^3.2 | ^4.0",
     "graze/data-structure": "^2.0",
-    "symfony/event-dispatcher": "^2.8 | ^3.2 | ^4.0" | ^5.0",
+    "symfony/event-dispatcher": "^2.8 | ^3.2 | ^4.0",
     "psr/log": "^1.0"
   },
   "require-dev": {

--- a/src/Event/EventDispatcherTrait.php
+++ b/src/Event/EventDispatcherTrait.php
@@ -15,7 +15,7 @@ namespace Graze\ParallelProcess\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 trait EventDispatcherTrait
 {

--- a/src/Event/EventDispatcherTrait.php
+++ b/src/Event/EventDispatcherTrait.php
@@ -13,9 +13,9 @@
 
 namespace Graze\ParallelProcess\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 trait EventDispatcherTrait
 {
@@ -60,7 +60,7 @@ trait EventDispatcherTrait
     protected function dispatch($name, Event $event)
     {
         $this->assertEventName($name);
-        $this->getEventDispatcher()->dispatch($name, $event);
+        $this->getEventDispatcher()->dispatch($event, $name);
         return $this;
     }
 

--- a/src/Event/PriorityChangedEvent.php
+++ b/src/Event/PriorityChangedEvent.php
@@ -14,7 +14,7 @@
 namespace Graze\ParallelProcess\Event;
 
 use Graze\ParallelProcess\PrioritisedInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class PriorityChangedEvent extends Event
 {

--- a/src/Event/RunEvent.php
+++ b/src/Event/RunEvent.php
@@ -14,7 +14,7 @@
 namespace Graze\ParallelProcess\Event;
 
 use Graze\ParallelProcess\RunInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class RunEvent extends Event
 {


### PR DESCRIPTION
Is it possible to create a new version for parallel-process.As with Symfony process and Event dispatcher changes, existing will not work for Symfony process and Event dispatcher version  are less <5.
Creating a new version will help people who want to use PHP 8 and updated Symfony process and Event Dispatcher(>=5.0) and previous version can be used as it is.

Kindly let me know if any more contribution required from my side.