### PR TITLE
Raise mockery/mockery floor to ^1.3.1 for PHPUnit 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "psr/log": "^1.0"
   },
   "require-dev": {
-    "mockery/mockery": "^1.0",
+    "mockery/mockery": "^1.3.1",
     "phpunit/phpunit": "^8.5.52",
     "squizlabs/php_codesniffer": "^3.3.1",
     "graze/standards": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e5047e547f24230866ea196de65cd0da",
+    "content-hash": "3984bf50996842cda23d15d2bbc0d428",
     "packages": [
         {
             "name": "graze/data-structure",


### PR DESCRIPTION
## Summary

The `--prefer-lowest` CI job (added in #34) surfaced that the declared `mockery/mockery: ^1.0` floor **cannot actually install** against the PHPUnit 8 the project now requires:

```
PHP Fatal error: Declaration of Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration::assertPostConditions()
must be compatible with PHPUnit\Framework\TestCase::assertPostConditions(): void
```

Mockery added the `: void` return types PHPUnit 8 requires in 1.2.3 / 1.3.0, so the real floor is higher than `^1.0`. This raises it to **`^1.3.1`** (the 1.3.x LTS line, PHP 7.2–8.0).

Only the *minimum* was wrong — the default (highest) resolution already picked a modern Mockery, so this doesn't change the committed lock's resolved versions, only the constraint + content-hash.

## Verification (PHP 7.4)

- `--prefer-lowest`: resolves mockery **1.3.1** + symfony/console 4.0 + symfony/event-dispatcher 5.0 + phpunit 8.5.52 → **131 tests pass**.
- default resolution → **131 tests pass**, phpcs clean.

> With this merged, #34's `PHP 7.4 (lowest)` job goes green and its `continue-on-error` can be dropped to make it a hard gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)