### PR TITLE
Makefile: target PHP 7.4 (and matrix 8.0-8.5), use phpcs.xml.dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL = /bin/sh
 
 DOCKER = $(shell which docker)
-PHP_VER := 7.2
+PHP_VER := 7.4
 IMAGE := graze/php-alpine:${PHP_VER}-test
 VOLUME := /srv
 DOCKER_RUN_BASE := ${DOCKER} run --rm -t -v $$(pwd):${VOLUME} -w ${VOLUME}
@@ -41,10 +41,10 @@ test: ## Run the unit and integration testsuites.
 test: lint test-unit
 
 lint: ## Run phpcs against the code.
-	${DOCKER_RUN} vendor/bin/phpcs -p --warning-severity=0 src/ tests/
+	${DOCKER_RUN} vendor/bin/phpcs --standard=./phpcs.xml.dist -p --warning-severity=0 src/ tests/
 
 lint-fix: ## Run phpcsf and fix possible lint errors.
-	${DOCKER_RUN} vendor/bin/phpcbf -p src/ tests/
+	${DOCKER_RUN} vendor/bin/phpcbf --standard=./phpcs.xml.dist -p src/ tests/
 
 test-unit: ## Run the unit testsuite.
 	${DOCKER_RUN} vendor/bin/phpunit --testsuite unit
@@ -58,10 +58,13 @@ test-matrix-lowest: ## Test all version, with the lowest version
 	${MAKE} build-update
 
 test-matrix: ## Run the unit tests against multiple targets.
-	${MAKE} PHP_VER="5.6" build-update test
-	${MAKE} PHP_VER="7.0" build-update test
-	${MAKE} PHP_VER="7.1" build-update test
-	${MAKE} PHP_VER="7.2" build-update test
+	${MAKE} PHP_VER="7.4" build-update test
+	${MAKE} PHP_VER="8.0" build-update test
+	${MAKE} PHP_VER="8.1" build-update test
+	${MAKE} PHP_VER="8.2" build-update test
+	${MAKE} PHP_VER="8.3" build-update test
+	${MAKE} PHP_VER="8.4" build-update test
+	${MAKE} PHP_VER="8.5" build-update test
 
 test-coverage: ## Run all tests and output coverage to the console.
 	${DOCKER_RUN} phpdbg7 -qrr vendor/bin/phpunit --coverage-text


### PR DESCRIPTION
## Summary

`make test` is broken on master because the Makefile defaults to PHP 7.2 and composer now requires PHP >= 7.4 — every target fatals at composer's platform check:

```
Your Composer dependencies require a PHP version ">= 7.4.0". You are running 7.2.26.
PHP Fatal error: ... in /srv/vendor/composer/platform_check.php:22
```

## Changes

- **`PHP_VER` default `7.2` → `7.4`** (the supported floor).
- **`lint` / `lint-fix`** pass `--standard=./phpcs.xml.dist` to phpcs/phpcbf so local lint matches CI (and applies the mixed-type-hint exclusion added in #36).
- **`test-matrix`** updated: PHP **7.4 + 8.0, 8.1, 8.2, 8.3, 8.4, 8.5** (drop EOL 5.6/7.0/7.1/7.2). `graze/php-alpine` publishes `-test` tags for all of these, so `make test-matrix` actually runs the full matrix locally.

## Verification

- `make test` (default PHP 7.4) → PHPUnit 9.6.34 on PHP 7.4.26: **131 tests / 696 assertions, OK.**
- `make PHP_VER=8.5 test` → PHPUnit 9.6.34 on PHP 8.5: **131 tests / 696 assertions, OK** (with PHP 8.x deprecation notices that don't fail the suite — implicit-nullable params in `Display\Lines`/`Display\Table`, `PriorityPool` `Serializable`, `graze/data-structure` `Countable::count` return type. Worth a follow-up issue but not a blocker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)